### PR TITLE
Fixes #5 crossorigin in HTML is crossOrigin in DOM

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -56,6 +56,9 @@ var Script2 = {
       // in code getting executed out of order from how it is inlined on the page.
       s.async = false // therefore set this to false
       s.src = src
+      // crossorigin in HTML and crossOrigin in the DOM per HTML spec
+      // https://html.spec.whatwg.org/multipage/embedded-content.html#dom-img-crossorigin
+      s.crossOrigin = opts.crossorigin
       // inspiration from: https://github.com/eldargab/load-script/blob/master/index.js
       // and: https://github.com/ded/script.js/blob/master/src/script.js#L70-L82
       s.onload = () => { Script2.loaded[src] = 1; resolve(src) }


### PR DESCRIPTION
This should fix the issue where the crossorigin property was not
being written out to the script tag in the DOM. The HTML
property is all lower case, but the DOM spec requires it to
be camel cased.

See:

https://github.com/w3c/webappsec-subresource-integrity/issues/24
https://html.spec.whatwg.org/multipage/embedded-content.html#dom-img-crossorigin