### PR TITLE
setting loading promise on request (not on load) to avoid duplicate l…

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -55,8 +55,7 @@ var Script2 = {
     Script2.installed = true
   },
   load (src, opts = {parent: document.head}) {
-    return Script2.loaded[src] ? Promise.resolve(src)
-    : new Promise(function (resolve, reject) {
+    if (_.isUndefined(Script2.loaded[src])) Script2.loaded[src] = new Promise((resolve, reject) => {
       var s = document.createElement('script')
       // omit the special options that Script2 supports
       _.defaults2(s, _.omit(opts, ['unload', 'parent']), {type: 'text/javascript'})
@@ -79,6 +78,7 @@ var Script2 = {
       s.onerror = () => reject(new Error(src))
       opts.parent.appendChild(s)
     })
+    return Script2.loaded[src]
   }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -55,7 +55,7 @@ var Script2 = {
     Script2.installed = true
   },
   load (src, opts = {parent: document.head}) {
-    if (_.isUndefined(Script2.loaded[src])) Script2.loaded[src] = new Promise((resolve, reject) => {
+    if (!Script2.loaded[src]) Script2.loaded[src] = new Promise((resolve, reject) => {
       var s = document.createElement('script')
       // omit the special options that Script2 supports
       _.defaults2(s, _.omit(opts, ['unload', 'parent']), {type: 'text/javascript'})
@@ -72,7 +72,7 @@ var Script2 = {
       }
       // inspiration from: https://github.com/eldargab/load-script/blob/master/index.js
       // and: https://github.com/ded/script.js/blob/master/src/script.js#L70-L82
-      s.onload = () => { Script2.loaded[src] = 1; resolve(src) }
+      s.onload = () => resolve(src)
       // IE should now support onerror and onload. If necessary, take a look
       // at this to add older IE support: http://stackoverflow.com/a/4845802/1781435
       s.onerror = () => reject(new Error(src))


### PR DESCRIPTION
closes #12 
Setting loading promise on request (not on load) to avoid duplicate loadings before load were finished
See https://github.com/taoeffect/vue-script2/issues/12#issuecomment-405803795

PROPOSAL (backward incompatible): rename Script2.loaded to Script2.load because we also store promises which is still in progress. What do you think?

Also:
1. fixed verbose async=false (will act as async=true previously because of isUndefined check)
2. added events on script load and script error for usage like this:
```vue
<template>
<script2 src="myscript.js" @load="loaded" />
<template>
<script>
export default {
   methods: {
       loaded () {
          window.myscriptModule.youVeGotTheIdea()
       }
   }
}
</script>
```